### PR TITLE
Use env shebang for zsh to improve portability

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 zmodload zsh/stat
 zmodload zsh/datetime

--- a/misc/fzf-wrapper.zsh
+++ b/misc/fzf-wrapper.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 local -i ret=0
 local -a files

--- a/zsh/datetime.zsh
+++ b/zsh/datetime.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 __zsh_history::datetime::today()
 {

--- a/zsh/filter.zsh
+++ b/zsh/filter.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 __zsh_history::filter::grep()
 {

--- a/zsh/history.zsh
+++ b/zsh/history.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 __zsh_history::history::add()
 {

--- a/zsh/hook.zsh
+++ b/zsh/hook.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 autoload -Uz add-zsh-hook
 

--- a/zsh/keybind.zsh
+++ b/zsh/keybind.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 __zsh_history::keybind::get_all()
 {

--- a/zsh/substring.zsh
+++ b/zsh/substring.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 __zsh_history::substring::search_begin()
 {

--- a/zsh/utils.zsh
+++ b/zsh/utils.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 __zsh_history::utils::get_filter()
 {


### PR DESCRIPTION
On systems that do not follow the FHS (like [NixOS](https://nixos.org/)), `/bin/zsh` may not exist.
Using `/usr/bin/env zsh` as a shebang improves portability for such systems.